### PR TITLE
Put `func_MCMC()` progressbar under `verbose`

### DIFF
--- a/R/func_MCMC.R
+++ b/R/func_MCMC.R
@@ -155,8 +155,10 @@ func_MCMC <- function(survObj, hyperpar, initial,
   # MCMC sampling
 
   # Initializes the progress bar
-  if (verbose) cat("  Running MCMC iterations ...\n")
-  pb <- txtProgressBar(min = 0, max = nIter, style = 3, width = 50, char = "=")
+  if (verbose) {
+    cat("  Running MCMC iterations ...\n")
+    pb <- txtProgressBar(min = 0, max = nIter, style = 3, width = 50, char = "=")
+  }
 
   for (M in 1:nIter) {
     # if (method %in% c("CoxBVSSL", "Sub-struct") ||
@@ -283,9 +285,9 @@ func_MCMC <- function(survObj, hyperpar, initial,
     # }
 
     # Sets the progress bar to the current state
-    setTxtProgressBar(pb, M)
+    if (verbose) setTxtProgressBar(pb, M)
   } # the end of MCMC sampling
-  close(pb) # Close the connection of progress bar
+  if (verbose) close(pb) # Close the connection of progress bar
 
   if (S == 1 && MRF_G) {
     mcmcOutcome$gamma.margin <- mcmcOutcome$gamma.margin / (nIter - burnin)


### PR DESCRIPTION
Otherwise, the `pb` would be drawn even if the user sets `verbose = FALSE` on `BayesSurvive()` (which I assume is not the intended behaviour).
